### PR TITLE
Fix #3: FastAPI backend - recipes CRUD

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,11 @@
 """Chefs Quest FastAPI backend."""
 
 from fastapi import FastAPI
+from backend.routers import recipes
 
 app = FastAPI(title="Chefs Quest API")
+
+app.include_router(recipes.router)
 
 
 @app.get("/health")

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI routers."""

--- a/backend/routers/recipes.py
+++ b/backend/routers/recipes.py
@@ -1,0 +1,52 @@
+"""Recipe CRUD endpoints."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from backend.database import get_db
+from backend.models.recipe import Recipe
+from backend.schemas.recipe import RecipeCreate, RecipeUpdate, RecipeResponse
+
+router = APIRouter(prefix="/recipes", tags=["recipes"])
+
+
+@router.get("/", response_model=list[RecipeResponse])
+def list_recipes(db: Session = Depends(get_db)):
+    return db.query(Recipe).all()
+
+
+@router.get("/{recipe_id}", response_model=RecipeResponse)
+def get_recipe(recipe_id: int, db: Session = Depends(get_db)):
+    recipe = db.get(Recipe, recipe_id)
+    if not recipe:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    return recipe
+
+
+@router.post("/", response_model=RecipeResponse, status_code=201)
+def create_recipe(body: RecipeCreate, db: Session = Depends(get_db)):
+    recipe = Recipe(**body.model_dump())
+    db.add(recipe)
+    db.commit()
+    db.refresh(recipe)
+    return recipe
+
+
+@router.put("/{recipe_id}", response_model=RecipeResponse)
+def update_recipe(recipe_id: int, body: RecipeUpdate, db: Session = Depends(get_db)):
+    recipe = db.get(Recipe, recipe_id)
+    if not recipe:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(recipe, field, value)
+    db.commit()
+    db.refresh(recipe)
+    return recipe
+
+
+@router.delete("/{recipe_id}", status_code=204)
+def delete_recipe(recipe_id: int, db: Session = Depends(get_db)):
+    recipe = db.get(Recipe, recipe_id)
+    if not recipe:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    db.delete(recipe)
+    db.commit()

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic schemas for Chefs Quest API."""

--- a/backend/schemas/recipe.py
+++ b/backend/schemas/recipe.py
@@ -1,0 +1,48 @@
+"""Pydantic schemas for recipes."""
+
+from pydantic import BaseModel
+
+
+class RecipeStepSchema(BaseModel):
+    id: int
+    step_number: int
+    instruction: str
+
+    model_config = {"from_attributes": True}
+
+
+class RecipeIngredientSchema(BaseModel):
+    id: int
+    name: str
+    amount: str | None
+    unit: str | None
+
+    model_config = {"from_attributes": True}
+
+
+class RecipeBase(BaseModel):
+    title: str
+    description: str | None = None
+    difficulty: str
+    xp_reward: int = 0
+    is_locked: bool = True
+
+
+class RecipeCreate(RecipeBase):
+    pass
+
+
+class RecipeUpdate(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    difficulty: str | None = None
+    xp_reward: int | None = None
+    is_locked: bool | None = None
+
+
+class RecipeResponse(RecipeBase):
+    id: int
+    steps: list[RecipeStepSchema] = []
+    ingredients: list[RecipeIngredientSchema] = []
+
+    model_config = {"from_attributes": True}


### PR DESCRIPTION
Closes #3

## Summary
- Pydantic schemas med nested steps & ingredients i response
- 5 CRUD-endpoints under `/recipes`
- Router inkluderad i `main.py`